### PR TITLE
Fix s:open_fallback() on windows

### DIFF
--- a/autoload/devdocs.vim
+++ b/autoload/devdocs.vim
@@ -36,7 +36,7 @@ function! s:open_fallback(url) abort
     elseif s:IS_OS_X
         call system('open ' . url)
     elseif s:IS_WINDOWS
-        call system('start ' . url)
+        call system('cmd /q /c start "" ' . url)
     else
         echoerr 'Unknown platform. devdocs.vim doesn''t know how to open URL: ' . url
         return


### PR DESCRIPTION
`start` does not seem to be supported directly by `system()` on windows. Indirectly calling it through `cmd.exe` works well.
