### PR TITLE
.gitignore file created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
added doc/tags into gitignore
It seems that this file is periodically generated when using
devdocs.vim as git submodule (using pathogen or pack/ folder)
thus making submodule dirty